### PR TITLE
Keep nose as test, not install time dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ smallest number of bins."""
 
 setup(
     name='rectpack',
-    version='0.2.1',
+    version='0.2.2',
     description=long_description, 
 
     # Main homepage
@@ -28,7 +28,6 @@ setup(
 
     # package
     packages = ['rectpack'],
-    install_requires = ['nose', 'unittest2'],
     zip_safe = False,
 
     # Tests


### PR DESCRIPTION
`pip install rectpack` unnecessarily pulls in `nose` and `unittest2` dependencies, they should only be test dependencies.
